### PR TITLE
Floor VGIS at zero

### DIFF
--- a/src/components/GIS.jl
+++ b/src/components/GIS.jl
@@ -39,7 +39,7 @@
         else
 
            vv.Diff_VGIS[tt] = vv.avoldot * sign(vv.TD[tt-1]) * vv.TD[tt-1] ^ 2 * vv.VGIS[tt-1] ^ pp.expvol
-           vv.VGIS[tt] = (vv.Diff_VGIS[tt] < 0 ? vv.VGIS[tt-1] + vv.Diff_VGIS[tt]*pp.f_GIS[tt] : vv.VGIS[tt-1])
+           vv.VGIS[tt] = max(0, vv.Diff_VGIS[tt] < 0 ? vv.VGIS[tt-1] + vv.Diff_VGIS[tt]*pp.f_GIS[tt] : vv.VGIS[tt-1])
            vv.T_GISstar[tt] = pp.tmaxa * (1 - vv.VGIS[tt]) ^ pp.exptstar
            vv.TD[tt] = pp.T_AT[tt] - vv.T_GISstar[tt] + 0.00001
 


### PR DESCRIPTION
The `VGIS` variable in `src/components/GIS.jl` denotes the "volume of the GIS relative to initial volume" in %, but it can currently reach negative values for outlier Monte Carlo runs. Flooring `VGIS` at zero resolves this issue.

Since the difference in VGIS between timesteps (`Diff_VGIS`) is a product of multiple terms including `vv.VGIS[tt-1] ^ pp.expvol`, the floor also ensures that `Diff_VGIS` will be equal to zero once the zero lower bound is reached