### PR TITLE
Add SAF switch to runsim() in montecarlo.jl

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,8 @@ order):
     otherwise false.
   - `amoc_used`: Set to true if the AMOC component is included;
     otherwise false.
+  - `saf_used`: Set to true if the SAF component is included;
+    otherwise false.    
   - `amazon_calib`: May be one of the options described in the
    deterministic use case or "none" if the Amazon dieback component is
    excluded.
@@ -252,6 +254,7 @@ draws = getsim(500, "Fit of Hope and Schaefer (2016)", # PCF
 results = runsim(model, draws, true, # ism_used
                  true, # omh_used
                  true, # amoc_used
+                 true, # saf_used
                  "Cai et al. central value", # AMAZ
                  "Distribution") # WAIS
 ```

--- a/src/montecarlo.jl
+++ b/src/montecarlo.jl
@@ -221,7 +221,7 @@ function getsim(trials::Int64, pcf_calib::String, amazon_calib::String, gis_cali
     draws
 end
 
-function runsim(model::Model, draws::DataFrame, ism_used::Bool, omh_used::Bool, amoc_used::Bool, amazon_calib::String, wais_calib::String; save_rvs::Bool=true)
+function runsim(model::Model, draws::DataFrame, ism_used::Bool, omh_used::Bool, amoc_used::Bool, saf_used::Bool, amazon_calib::String, wais_calib::String; save_rvs::Bool=true)
     if wais_calib == "Distribution"
         set_param!(model, :WAISmodel, :waisrate, :WAISmodel_waisrate, 0.0033) # set up global connection
     end
@@ -240,7 +240,9 @@ function runsim(model::Model, draws::DataFrame, ism_used::Bool, omh_used::Bool, 
 
         # SAF
 
-        update_param!(inst, :SAFModel_ECS, draws.TemperatureModel_fair_ECS[ii]) # SAFModel.ECS
+        if saf_used
+            update_param!(inst, :SAFModel_ECS, draws.TemperatureModel_fair_ECS[ii]) # SAFModel.ECS
+        end
 
         # Damages
 

--- a/test/test_montecarlo_tp.jl
+++ b/test/test_montecarlo_tp.jl
@@ -29,6 +29,7 @@ for do_test in ["notp", "full", "some"]
         results = runsim(model, draws, true, # ism_used
                          true, # omh_used
                          true, # amoc_used
+                         true, # saf_used
                          "Cai et al. central value", # AMAZ
                          "Distribution") # WAIS
     elseif do_test == "some" # PCFGISISMSAF
@@ -46,6 +47,7 @@ for do_test in ["notp", "full", "some"]
         results = runsim(model, draws, true, # ism_used
                          false, # omh_used
                          false, # amoc_used
+                         true, # saf_used
                          "none", # AMAZ
                          "none") # WAIS
     elseif do_test == "notp"


### PR DESCRIPTION
This adds a switch called `saf_used` (similar to the existing switches for other tipping points) to `runsim()` to make it possible to run the model in Monte Carlo mode when the SAF component is deactivated when calling `full_model()`

Also includes corresponding updates of `README.md` and the two unit tests affected (which both use the SAF component)